### PR TITLE
Require vagrant-vbguest for managing virtualbox guest additions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,15 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+REQUIRED_PLUGINS = %w(vagrant-vbguest)
+exit unless REQUIRED_PLUGINS.all? do |plugin|
+  Vagrant.has_plugin?(plugin) || (
+  puts "The #{plugin} plugin is required. Please install it with:"
+  puts "$ vagrant plugin install #{plugin}"
+  false
+  )
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.forward_agent = true
   config.vm.box = "litaio/development-environment"


### PR DESCRIPTION
This is a fix for https://github.com/litaio/development-environment/issues/1

I found Vagrant.require_plugin over on [this stackoverflow thread](http://stackoverflow.com/questions/19492738/demand-a-vagrant-plugin-within-the-vagrantfile), but that's been deprecated and has no effect. I found an alternative over on https://github.com/mitchellh/vagrant/issues/4349 using this: https://github.com/rapidftr/RapidFTR/blob/master/Vagrantfile#L7

Basically copied that, and update it to vagrant-vbguest.

Not sure if it's something in my local environment, but I hit something like https://github.com/mitchellh/vagrant/issues/3769 when installing the plugin, but I think that may be more my environment. I was able to work around that with `export NOKOGIRI_USE_SYSTEM_LIBRARIES=true`.
